### PR TITLE
Shorten Lair Branches to 3 floors

### DIFF
--- a/crawl-ref/source/branch-data.h
+++ b/crawl-ref/source/branch-data.h
@@ -60,7 +60,7 @@ const Branch branches[NUM_BRANCHES] =
       GREEN, BROWN,
       'L', {}, BRANCH_NOISE_NORMAL },
 
-    { BRANCH_SWAMP, BRANCH_LAIR, 2, 4, 4, 15,
+    { BRANCH_SWAMP, BRANCH_LAIR, 2, 4, 3, 15,
       BFLAG_DANGEROUS_END | BFLAG_SPOTTY,
       DNGN_ENTER_SWAMP, DNGN_EXIT_SWAMP, NUM_FEATURES,
       "Swamp", "the Swamp", "Swamp",
@@ -68,7 +68,7 @@ const Branch branches[NUM_BRANCHES] =
       BROWN, BROWN,
       'S', { RUNE_SWAMP }, BRANCH_NOISE_NORMAL },
 
-    { BRANCH_SHOALS, BRANCH_LAIR, 2, 4, 4, 15,
+    { BRANCH_SHOALS, BRANCH_LAIR, 2, 4, 3, 15,
       BFLAG_DANGEROUS_END,
       DNGN_ENTER_SHOALS, DNGN_EXIT_SHOALS, NUM_FEATURES,
       "Shoals", "the Shoals", "Shoals",
@@ -76,7 +76,7 @@ const Branch branches[NUM_BRANCHES] =
       BROWN, BROWN,
       'A', { RUNE_SHOALS }, BRANCH_NOISE_LOUD },
 
-    { BRANCH_SNAKE, BRANCH_LAIR, 2, 4, 4, 15,
+    { BRANCH_SNAKE, BRANCH_LAIR, 2, 4, 3, 15,
       BFLAG_DANGEROUS_END,
       DNGN_ENTER_SNAKE, DNGN_EXIT_SNAKE, NUM_FEATURES,
       "Snake Pit", "the Snake Pit", "Snake",
@@ -84,7 +84,7 @@ const Branch branches[NUM_BRANCHES] =
       LIGHTGREEN, YELLOW,
       'P', { RUNE_SNAKE }, BRANCH_NOISE_NORMAL },
 
-    { BRANCH_SPIDER, BRANCH_LAIR, 2, 4, 4, 15,
+    { BRANCH_SPIDER, BRANCH_LAIR, 2, 4, 3, 15,
       BFLAG_DANGEROUS_END,
       DNGN_ENTER_SPIDER, DNGN_EXIT_SPIDER, NUM_FEATURES,
       "Spider Nest", "the Spider Nest", "Spider",

--- a/crawl-ref/source/mon-pick-data.h
+++ b/crawl-ref/source/mon-pick-data.h
@@ -1,3 +1,9 @@
+//FLAT,  full chance throughout the range
+//SEMI, // 50% chance at range ends, 100% in the middle
+//PEAK, // 0% chance just outside range ends, 100% in the middle, range
+      // ends typically get ~20% or more
+//RISE, // linearly from near-zero to 100%, increasing with depth
+//FALL, // linearly from 100% at the start to near-zero
 static const pop_entry pop_d[] =
 { // Dungeon (OOD cap: 27)
   { -2,  8,  515, SEMI, MONS_GIANT_COCKROACH },


### PR DESCRIPTION
As requested, this change was done to force tighter and more exciting
gameplay by restricting the experience available to the player.

To : NP7, I have combed over the .des files in this reference pull request as well : https://github.com/crawl/crawl/commit/38e14289646dd9edd93fea48c627e6a15ab22570 and found nothing to really amend. However, it might be wise for you to double-check it as well