### PR TITLE
Always mulch

### DIFF
--- a/crawl-ref/source/dat/des/portals/bailey.des
+++ b/crawl-ref/source/dat/des/portals/bailey.des
@@ -67,15 +67,15 @@ end
 
 -- Axes.
 function axe_returning(e)
-  e.mons("generate_awake kobold ; tomahawk ego:returning ident:type q:4 | \
-                                  tomahawk ego:returning ident:type q:3 / \
-          generate_awake hobgoblin ; tomahawk ego:returning ident:type q:4 | \
-                                     tomahawk ego:returning ident:type q:3")
+  e.mons("generate_awake kobold ; tomahawk ident:type q:80 | \
+                                  tomahawk ident:type q:60 / \
+          generate_awake hobgoblin ; tomahawk ident:type q:80 | \
+                                     tomahawk ident:type q:60")
 end
 
 function kobold_axe_returning(e)
-  e.mons("generate_awake kobold ; tomahawk ego:returning ident:type q:4 | \
-                                  tomahawk ego:returning ident:type q:3")
+  e.mons("generate_awake kobold ; tomahawk ident:type q:80 | \
+                                  tomahawk ident:type q:60")
 end
 
 function easy_axe_fighter(e)

--- a/crawl-ref/source/describe.cc
+++ b/crawl-ref/source/describe.cc
@@ -1395,9 +1395,7 @@ static string _describe_ammo(const item_def &item)
         case SPMSL_CURARE:
             description += "It is tipped with a substance that causes "
                            "asphyxiation, dealing direct damage as well as "
-                           "poisoning and slowing those it strikes.\n"
-                           "It is twice as likely to be destroyed on impact as "
-                           "other needles.";
+                           "poisoning and slowing those it strikes.";
             break;
         case SPMSL_PARALYSIS:
             description += "It is tipped with a paralysing substance.";
@@ -1476,10 +1474,8 @@ static string _describe_ammo(const item_def &item)
             _append_skill_target_desc(description, SK_THROWING, target_skill);
     }
 
-    if (ammo_always_destroyed(item))
+    if (!ammo_never_destroyed(item))
         description += "\n\nIt will always be destroyed on impact.";
-    else if (!ammo_never_destroyed(item))
-        description += "\n\nIt may be destroyed on impact.";
 
     return description;
 }

--- a/crawl-ref/source/item-prop.cc
+++ b/crawl-ref/source/item-prop.cc
@@ -2128,22 +2128,6 @@ launch_retval is_launched(const actor *actor, const item_def *launcher,
     return is_throwable(actor, missile) ? launch_retval::THROWN : launch_retval::FUMBLED;
 }
 
-
-/**
- * Returns whether a given missile will always destroyed on impact.
- *
- * @param missile      The missile in question.
- * @return             Whether the missile should always be destroyed on
- *                     impact.
- */
-bool ammo_always_destroyed(const item_def &missile)
-{
-    const int brand = get_ammo_brand(missile);
-    return brand == SPMSL_CHAOS
-           || brand == SPMSL_DISPERSAL
-           || brand == SPMSL_EXPLODING;
-}
-
 /**
  * Returns whether a given missile will never destroyed on impact.
  *
@@ -2153,17 +2137,6 @@ bool ammo_always_destroyed(const item_def &missile)
 bool ammo_never_destroyed(const item_def &missile)
 {
     return missile.sub_type == MI_THROWING_NET;
-}
-
-/**
- * Returns the one_chance_in for a missile type for be destroyed on impact.
- *
- * @param missile_type      The missile type to get the mulch chance for.
- * @return                  The inverse of the missile type's mulch chance.
- */
-int ammo_type_destroy_chance(int missile_type)
-{
-    return Missile_prop[ Missile_index[missile_type] ].mulch_rate;
 }
 
 /**

--- a/crawl-ref/source/item-prop.h
+++ b/crawl-ref/source/item-prop.h
@@ -168,9 +168,7 @@ bool is_throwable(const actor *actor, const item_def &wpn,
 launch_retval is_launched(const actor *actor, const item_def *launcher,
                           const item_def &missile) PURE;
 
-bool ammo_always_destroyed(const item_def &missile) PURE;
 bool ammo_never_destroyed(const item_def &missile) PURE;
-int  ammo_type_destroy_chance(int missile_type) PURE;
 int  ammo_type_damage(int missile_type) PURE;
 
 

--- a/crawl-ref/source/makeitem.cc
+++ b/crawl-ref/source/makeitem.cc
@@ -544,8 +544,7 @@ static special_missile_type _determine_missile_brand(const item_def& item,
                                     nw, SPMSL_POISONED);
         break;
     case MI_JAVELIN:
-        rc = random_choose_weighted(30, SPMSL_RETURNING,
-                                    32, SPMSL_PENETRATION,
+        rc = random_choose_weighted(32, SPMSL_PENETRATION,
                                     32, SPMSL_POISONED,
                                     21, SPMSL_STEEL,
                                     20, SPMSL_SILVER,
@@ -556,7 +555,6 @@ static special_missile_type _determine_missile_brand(const item_def& item,
                                     10, SPMSL_SILVER,
                                     10, SPMSL_STEEL,
                                     12, SPMSL_DISPERSAL,
-                                    28, SPMSL_RETURNING,
                                     15, SPMSL_EXPLODING,
                                     nw, SPMSL_NORMAL);
         break;
@@ -635,8 +633,6 @@ bool is_missile_brand_ok(int type, int brand, bool strict)
     {
     case SPMSL_POISONED:
         return type == MI_JAVELIN || type == MI_TOMAHAWK;
-    case SPMSL_RETURNING:
-        return type == MI_JAVELIN || type == MI_TOMAHAWK;
     case SPMSL_CHAOS:
         return type == MI_TOMAHAWK || type == MI_JAVELIN;
     case SPMSL_PENETRATION:
@@ -683,12 +679,16 @@ static void _generate_missile_item(item_def& item, int force_type,
     // No fancy rocks -- break out before we get to special stuff.
     if (item.sub_type == MI_LARGE_ROCK)
     {
-        item.quantity = 2 + random2avg(5,2);
+        // Vanilla gives 2...6 with 1/25 mulch rate.
+        // This seems absurdly generous so I'm only doubling it.
+        item.quantity = 4 + random2avg(9,2);
         return;
     }
     else if (item.sub_type == MI_STONE)
     {
-        item.quantity = 1 + random2(7) + random2(10) + random2(12) + random2(10);
+        // Vanilla: 1 + 0...6 + 0...9 + 0...11 + 0...9
+        // On average is 1 + 3 + 4.5 + 5.5 + 4.5 = 18.5 with 1/8 mulch rate.
+        item.quantity = 1 + random2avg(280,4);
         return;
     }
     else if (item.sub_type == MI_THROWING_NET) // no fancy nets, either
@@ -703,17 +703,37 @@ static void _generate_missile_item(item_def& item, int force_type,
                            _determine_missile_brand(item, item_level));
     }
 
-    // Reduced quantity if special.
-    if (item.sub_type == MI_JAVELIN || item.sub_type == MI_TOMAHAWK
-        || (item.sub_type == MI_NEEDLE && get_ammo_brand(item) != SPMSL_POISONED)
-        || get_ammo_brand(item) == SPMSL_RETURNING)
+    if (item.sub_type == MI_NEEDLE && get_ammo_brand(item) == SPMSL_CURARE)
     {
-        item.quantity = random_range(2, 8);
+        // Vanilla curare is 2...8 with 1/6 mulch rate.
+        item.quantity = random_range(12, 48);
+    }
+    else if (item.sub_type == MI_NEEDLE && get_ammo_brand(item) != SPMSL_POISONED)
+    {
+        // Vanilla special needles are 2...8 with 1/12 mulch rate.
+        item.quantity = random_range(24, 96);
+    }
+    else if (item.sub_type == MI_JAVELIN || item.sub_type == MI_TOMAHAWK)
+    {
+        // All tomahawks and javelins.
+        // Vanilla gives 2...8 with 1/20 mulch rate.
+        item.quantity = random_range(40, 160);
     }
     else if (get_ammo_brand(item) != SPMSL_NORMAL)
-        item.quantity = 1 + random2(7) + random2(10) + random2(10);
+    {
+        // This only catches basic (poisoned) needles now.
+        // In past versions, it also caught variant bolts, arrows, bullets.
+        // Vanilla gives 1 + 0...6 + 0...9 + 0...9.
+        // Average is 1 + 3 + 4.5 + 4.5 = 13 with 1/12 mulch rate.
+        item.quantity = 1 + random2avg(156, 3);
+    }
     else
-        item.quantity = 1 + random2(7) + random2(10) + random2(10) + random2(12);
+    {
+        // Normal arrows, bolts, bullets.
+        // Vanilla gives 1 + 0...6 + 0...9 + 0...9 + 0...11.
+        // Average is 1 + 3 + 4.5 + 4.5 + 5.5 = 18.5 with 1/8 mulch rate.
+        item.quantity = 1 + random2avg(280, 4);
+    }
 }
 
 static bool _armour_disallows_randart(int sub_type)

--- a/crawl-ref/source/mon-gear.cc
+++ b/crawl-ref/source/mon-gear.cc
@@ -1336,14 +1336,14 @@ static void _give_ammo(monster* mon, int level, bool mons_summoned)
                 set_item_ego_type(mitm[thing_created], OBJ_MISSILES,
                                   SPMSL_CURARE);
 
-                mitm[thing_created].quantity = random_range(4, 10);
+                mitm[thing_created].quantity = random_range(24, 60);
             }
             else if (mon->type == MONS_SPRIGGAN_RIDER)
             {
                 set_item_ego_type(mitm[thing_created], OBJ_MISSILES,
                                   SPMSL_CURARE);
 
-                mitm[thing_created].quantity = random_range(2, 4);
+                mitm[thing_created].quantity = random_range(12, 24);
             }
             else
             {
@@ -1352,7 +1352,7 @@ static void _give_ammo(monster* mon, int level, bool mons_summoned)
                                                          : SPMSL_POISONED);
 
                 if (get_ammo_brand(mitm[thing_created]) == SPMSL_CURARE)
-                    mitm[thing_created].quantity = random_range(2, 8);
+                    mitm[thing_created].quantity = random_range(12, 48);
             }
         }
         else
@@ -1375,7 +1375,7 @@ static void _give_ammo(monster* mon, int level, bool mons_summoned)
                 break;
 
             case MONS_JOSEPH:
-                mitm[thing_created].quantity += 2 + random2(7);
+                mitm[thing_created].quantity += 16 + random2(49);
                 break;
 
             default:
@@ -1405,7 +1405,7 @@ static void _give_ammo(monster* mon, int level, bool mons_summoned)
                     player_in_branch(BRANCH_ORC)? 9 : 20))
             {
                 weap_type = MI_TOMAHAWK;
-                qty       = random_range(4, 8);
+                qty       = random_range(80, 160);
             }
             break;
 
@@ -1413,13 +1413,13 @@ static void _give_ammo(monster* mon, int level, bool mons_summoned)
             if (one_chance_in(20))
             {
                 weap_type = MI_TOMAHAWK;
-                qty       = random_range(2, 5);
+                qty       = random_range(40, 100);
             }
             break;
 
         case MONS_URUG:
             weap_type  = MI_JAVELIN;
-            qty = random_range(4, 7);
+            qty = random_range(80, 140);
             break;
 
         case MONS_CHUCK:
@@ -1429,13 +1429,13 @@ static void _give_ammo(monster* mon, int level, bool mons_summoned)
 
         case MONS_POLYPHEMUS:
             weap_type  = MI_LARGE_ROCK;
-            qty        = random_range(8, 12);
+            qty        = random_range(16, 24);
             break;
 
         case MONS_MERFOLK_JAVELINEER:
         case MONS_MINOTAUR:
             weap_type  = MI_JAVELIN;
-            qty        = random_range(9, 23, 2);
+            qty        = random_range(180, 460, 2);
             if (one_chance_in(3))
                 level = ISPEC_GOOD_ITEM;
             break;
@@ -1445,7 +1445,7 @@ static void _give_ammo(monster* mon, int level, bool mons_summoned)
                 || active_monster_band == BAND_MERFOLK_JAVELINEER)
             {
                 weap_type  = MI_TOMAHAWK;
-                qty        = random_range(4, 8);
+                qty        = random_range(80, 160);
                 if (active_monster_band == BAND_MERFOLK_JAVELINEER)
                     break;
             }

--- a/crawl-ref/source/ng-setup.cc
+++ b/crawl-ref/source/ng-setup.cc
@@ -214,21 +214,21 @@ static void _give_ammo(weapon_type weapon, int plus)
     {
     case WPN_THROWN:
         if (species_can_throw_large_rocks(you.species))
-            newgame_make_item(OBJ_MISSILES, MI_LARGE_ROCK, 4 + plus);
+            newgame_make_item(OBJ_MISSILES, MI_LARGE_ROCK, 20 + (plus * 5));
         else if (you.body_size(PSIZE_TORSO) <= SIZE_SMALL)
-            newgame_make_item(OBJ_MISSILES, MI_TOMAHAWK, 8 + 2 * plus);
+            newgame_make_item(OBJ_MISSILES, MI_TOMAHAWK, 160 + (40 * plus));
         else
-            newgame_make_item(OBJ_MISSILES, MI_JAVELIN, 5 + plus);
+            newgame_make_item(OBJ_MISSILES, MI_JAVELIN, 100 + (20 * plus));
         newgame_make_item(OBJ_MISSILES, MI_THROWING_NET, 2);
         break;
     case WPN_SHORTBOW:
-        newgame_make_item(OBJ_MISSILES, MI_ARROW, 20);
+        newgame_make_item(OBJ_MISSILES, MI_ARROW, 160);
         break;
     case WPN_HAND_CROSSBOW:
-        newgame_make_item(OBJ_MISSILES, MI_BOLT, 20);
+        newgame_make_item(OBJ_MISSILES, MI_BOLT, 160);
         break;
     case WPN_HUNTING_SLING:
-        newgame_make_item(OBJ_MISSILES, MI_SLING_BULLET, 20);
+        newgame_make_item(OBJ_MISSILES, MI_SLING_BULLET, 160);
         break;
     default:
         break;

--- a/crawl-ref/source/throw.cc
+++ b/crawl-ref/source/throw.cc
@@ -1185,23 +1185,8 @@ bool thrown_object_destroyed(item_def *item, const coord_def& where)
     if (item->base_type != OBJ_MISSILES)
         return false;
 
-    if (ammo_always_destroyed(*item))
-        return true;
-
     if (ammo_never_destroyed(*item))
         return false;
 
-    const int base_chance = ammo_type_destroy_chance(item->sub_type);
-    const int brand = get_ammo_brand(*item);
-
-    // Inflate by 2 to avoid rounding errors.
-    const int mult = 2;
-    int chance = base_chance * mult;
-
-    if (brand == SPMSL_CURARE)
-        chance /= 2;
-
-    dprf("mulch chance: %d in %d", mult, chance);
-
-    return x_chance_in_y(mult, chance);
+    return true;
 }


### PR DESCRIPTION
All ammo always mulches, but it is spawned in greater quantities. Usually the quantity increase is proportional to the mulch rate, but I took a few liberties. Large rocks generally got a lower rate because they're very good and had an absurd 24/25 preservation rate. Ordinary kobolds that spawn with rocks still only get a couple.

Returning brand no longer spawns, since it's kinda useless when it always mulches. Chuck is the exception because he won't give up his collection so easily.