### PR TITLE
Corrosion tweak

### DIFF
--- a/crawl-ref/source/attack.cc
+++ b/crawl-ref/source/attack.cc
@@ -1201,7 +1201,7 @@ int attack::player_apply_slaying_bonuses(int damage, bool aux)
     if (!aux && using_weapon())
         damage_plus = get_weapon_plus();
     if (you.duration[DUR_CORROSION])
-        damage_plus -= 4 * you.props["corrosion_amount"].get_int();
+        damage_plus -= you.props["corrosion_amount"].get_int();
     damage_plus += slaying_bonus(!weapon && wpn_skill == SK_THROWING
                                  || (weapon && is_range_weapon(*weapon)
                                             && using_weapon()));

--- a/crawl-ref/source/output.cc
+++ b/crawl-ref/source/output.cc
@@ -917,7 +917,7 @@ static void _print_stats_wp(int y)
         item_def wpn = *you.weapon(); // copy
 
         if (you.duration[DUR_CORROSION] && wpn.base_type == OBJ_WEAPONS)
-            wpn.plus -= 4 * you.props["corrosion_amount"].get_int();
+            wpn.plus -= you.props["corrosion_amount"].get_int();
 
         text = wpn.name(DESC_PLAIN, true, false, true);
     }

--- a/crawl-ref/source/player.cc
+++ b/crawl-ref/source/player.cc
@@ -6145,7 +6145,7 @@ int player::armour_class(bool /*calc_unid*/) const
         AC += 700;
 
     if (duration[DUR_CORROSION])
-        AC -= 400 * you.props["corrosion_amount"].get_int();
+        AC -= 100 * you.props["corrosion_amount"].get_int();
 
     AC += sanguine_armour_bonus();
 
@@ -6751,28 +6751,21 @@ bool player::rot(actor *who, int amount, bool quiet, bool /*no_cleanup*/)
 
 bool player::corrode_equipment(const char* corrosion_source, int degree)
 {
-    // rCorr protects against 50% of corrosion.
-    if (res_corr())
-    {
-        degree = binomial(degree, 50);
-        if (!degree)
-        {
-            dprf("rCorr protects.");
-            return false;
-        }
-    }
     // always increase duration, but...
     increase_duration(DUR_CORROSION, 10 + roll_dice(2, 4), 50,
                       make_stringf("%s corrodes you!",
                                    corrosion_source).c_str());
 
     // the more corrosion you already have, the lower the odds of more
-    int prev_corr = props["corrosion_amount"].get_int();
+    int prev_corr = props["corrosion_amount"].get_int() / 4;
     bool did_corrode = false;
     for (int i = 0; i < degree; i++)
         if (!x_chance_in_y(prev_corr, prev_corr + 7))
         {
-            props["corrosion_amount"].get_int()++;
+            if (res_corr())
+                props["corrosion_amount"].get_int() += 2;
+            else
+                props["corrosion_amount"].get_int() += 4;
             prev_corr++;
             did_corrode = true;
         }

--- a/crawl-ref/source/player.cc
+++ b/crawl-ref/source/player.cc
@@ -6757,10 +6757,10 @@ bool player::corrode_equipment(const char* corrosion_source, int degree)
                                    corrosion_source).c_str());
 
     // the more corrosion you already have, the lower the odds of more
-    int prev_corr = props["corrosion_amount"].get_int() / 4;
+    int prev_corr = props["corrosion_amount"].get_int();
     bool did_corrode = false;
     for (int i = 0; i < degree; i++)
-        if (!x_chance_in_y(prev_corr, prev_corr + 7))
+        if (!x_chance_in_y(prev_corr, prev_corr + 28))
         {
             if (res_corr())
                 props["corrosion_amount"].get_int() += 2;

--- a/crawl-ref/source/status.cc
+++ b/crawl-ref/source/status.cc
@@ -208,7 +208,7 @@ bool fill_status_info(int status, status_info& inf)
 
     case DUR_CORROSION:
         inf.light_text = make_stringf("Corr (%d)",
-                          (-4 * you.props["corrosion_amount"].get_int()));
+                          (-1 * you.props["corrosion_amount"].get_int()));
         break;
 
     case DUR_NO_POTIONS:


### PR DESCRIPTION
Store corrosion internally as the displayed value instead of the number of stacks.

Corrosion applications do not randomly fail if the player has rCorr; instead they apply in -2s.

Corrosion has a chance to fail if you are already corroded. This now respects the amount of corrosion you have rather than the number of stacks, so with rCorr you still get corroded kinda quickish if you don't do anything about the corroder. This may be worth changing.

Monster corrosion resistance still flat blocks 50% of corrosion attempts, since corrosion is not a stacking status for monsters currently. This should maybe get a little more attention since it is possible to corrode things that you probably shouldn't be able to, such as the Royal Jelly, though you have to use Punk since the wand of acid can't do any damage to it.